### PR TITLE
feat(resources): add resource filter by categories

### DIFF
--- a/main.py
+++ b/main.py
@@ -3,11 +3,11 @@ CNCF Kathmandu Community Website
 A community website for Cloud Native Computing Foundation (CNCF) Kathmandu Chapter
 """
 
-from fastapi import FastAPI, Request, Form
+from fastapi import FastAPI, Request, Form, Path
 from fastapi.staticfiles import StaticFiles
 from fastapi.responses import HTMLResponse
 from fastapi.templating import Jinja2Templates
-from typing import Optional
+from typing import Optional, Annotated
 import os
 
 app = FastAPI(
@@ -90,16 +90,29 @@ async def events(request: Request):
     }
     return templates.TemplateResponse("events.html", context)
 
-
 @app.get("/resources", response_class=HTMLResponse)
 async def resources_page(request: Request):
     """Resources page"""
+    
     context = {
         "request": request,
         "title": "Resources - CNCF Kathmandu",
         "resources": resources
     }
     return templates.TemplateResponse("resources.html", context)
+
+@app.get("/resource/{type}", response_class=HTMLResponse)
+async def resources_page(request: Request, type: str):
+    """Filter Resource by type"""
+
+    filteredResource = [x for x in resources if x["type"].lower() == type]
+    context = {
+        "request": request,
+        "title": "Resources - CNCF Kathmandu",
+        "resources": filteredResource
+    }
+    return templates.TemplateResponse("resources.html", context)
+
 
 
 @app.get("/contact", response_class=HTMLResponse)

--- a/templates/resources.html
+++ b/templates/resources.html
@@ -12,12 +12,27 @@
     <div class="container">
         <div class="resources-section">
             <h2 class="section-title">Learning Resources</h2>
+            <select name="Category" id="categories" onchange="navigateToResource()" on>
+                <option value="/resources">--Select Resource Type--</option>
+                <option value="/resource/tutorial">Tutorial</option>
+                <option value="/resource/article">Article</option>
+                <option value="/resource/reference">Reference</option>
+            </select>
+            <script>
+                function navigateToResource() {
+                    const select = document.getElementById('categories');
+                    const selectedValue = select.value;
+                    if (selectedValue) {
+                        window.location.href = selectedValue
+                    }
+                }
+            </script>
             <div class="resources-grid">
                 {% for resource in resources %}
                 <div class="resource-card">
                     <div class="resource-type">{{ resource.type }}</div>
                     <h3>{{ resource.title }}</h3>
-                    <a href="{{ resource.link }}" class="btn btn-small">View Resource</a>
+                    <a href="{{ resource.link }}" class="btn btn-small">View Resource here</a>
                 </div>
                 {% endfor %}
             </div>


### PR DESCRIPTION
resolved [#24](https://github.com/CNCF-Kathmandu/CNCF-Kathmandu/issues/24)

This pull request adds feature to filter resources by category.

- I added a new API endpoint `/resource/{type}` to get category type to filter by from route param. 
- And also added a drop-down on `templates/resources.html`, from which we can select different resource categories and navigate to the same page with filtered resources.