### PR TITLE
feat(calendar): integrate event calendar view and global styling

### DIFF
--- a/main.py
+++ b/main.py
@@ -33,7 +33,7 @@ events_db = [
     {
         "id": 1,
         "title": "Kubernetes Workshop",
-        "date": "2024-11-15",
+        "date": "2025-11-15",
         "speaker": "John Doe",
         "description": "Learn Kubernetes from scratch",
         "status": "upcoming",
@@ -41,7 +41,7 @@ events_db = [
     {
         "id": 2,
         "title": "Docker Deep Dive",
-        "date": "2024-10-20",
+        "date": "2025-10-20",
         "speaker": "Jane Smith",
         "description": "Advanced Docker concepts",
         "status": "completed",
@@ -103,6 +103,18 @@ async def events(request: Request):
     return templates.TemplateResponse("events.html", context)
 
 
+# Displays the calendar view with all scheduled events
+@app.get("/calendar", response_class=HTMLResponse)
+async def calendar(request: Request):
+    """Calendar view showing all events"""
+    context = {
+        "request": request,
+        "title": "Calendar - CNCF Kathmandu",
+        "events": events_db,  # events list
+    }
+    return templates.TemplateResponse("calendar.html", context)
+
+
 # This function gets the `resources.html` page
 @app.get("/resources", response_class=HTMLResponse)
 async def resources_page(request: Request):
@@ -132,7 +144,7 @@ async def contact_post(
     email: str = Form(...),
     message: str = Form(...),
 ):
-  ]    """Contact page (POST)"""
+    """Contact page (POST)"""
     # In production, this would send an email or save to database
     context = {
         "request": request,

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -659,3 +659,51 @@ body {
     }
 }
 
+/* Calendar Component */
+.calendar-container {
+    max-width: 1000px;
+    margin: 4rem auto;
+    padding: 2rem;
+    background-color: var(--bg-light);
+    border-radius: 12px;
+    box-shadow: var(--shadow);
+}
+
+/* Event Modal */
+.event-modal {
+  display: none;
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  background-color: var(--bg-color);
+  padding: 2rem;
+  border-radius: 12px;
+  box-shadow: var(--shadow-lg);
+  z-index: 1000;
+  max-width: 400px;
+  width: 90%;
+  font-family: inherit;
+}
+
+.event-modal h2 {
+  font-size: 1.5rem;
+  color: var(--primary-color);
+  margin-bottom: 1rem;
+}
+
+.event-modal p {
+  font-size: 1rem;
+  margin-bottom: 0.5rem;
+  color: var(--text-color);
+}
+
+/* Modal Backdrop  */
+.modal-backdrop {
+  display: none;
+  position: fixed;
+  top: 0; left: 0;
+  width: 100%; height: 100%;
+  background: rgba(0,0,0,0.5);
+  z-index: 999;
+}

--- a/templates/base.html
+++ b/templates/base.html
@@ -6,6 +6,8 @@
     <title>{% block title %}{% endblock %}</title>
     <link rel="stylesheet" href="{{ url_for('static', path='/css/style.css') }}">
     <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+    <link href="https://cdn.jsdelivr.net/npm/fullcalendar@6.1.8/index.global.min.css" rel="stylesheet">
+    <script src="https://cdn.jsdelivr.net/npm/fullcalendar@6.1.8/index.global.min.js"></script>
 </head>
 <body>
     <nav class="navbar">
@@ -17,6 +19,7 @@
                 <li><a href="/" class="nav-link">Home</a></li>
                 <li><a href="/about" class="nav-link">About</a></li>
                 <li><a href="/events" class="nav-link">Events</a></li>
+                <li><a href="/calendar" class="nav-link">Calendar</a></li>
                 <li><a href="/resources" class="nav-link">Resources</a></li>
                 <li><a href="/contact" class="nav-link">Contact</a></li>
             </ul>
@@ -24,6 +27,33 @@
     </nav>
 
     {% block content %}{% endblock %}
+
+    <!-- Global Event Modal for calendar-->
+    <div class="event-modal" id="eventModal">
+        <h2 id="modalTitle"></h2>
+        <p><strong>Date:</strong> <span id="modalDate"></span></p>
+        <p><strong>Speaker:</strong> <span id="modalSpeaker"></span></p>
+        <p><strong>Description:</strong> <span id="modalDescription"></span></p>
+    </div>
+
+    <div class="modal-backdrop" id="modalBackdrop" onclick="closeModal()"></div>
+
+    <script>
+        function openModal(event) {
+          document.getElementById('modalTitle').textContent = event.title;
+          document.getElementById('modalDate').textContent = event.start.toISOString().split('T')[0];
+          document.getElementById('modalSpeaker').textContent = event.extendedProps.speaker;
+          document.getElementById('modalDescription').textContent = event.extendedProps.description;
+
+          document.getElementById('eventModal').style.display = 'block';
+          document.getElementById('modalBackdrop').style.display = 'block';
+        }
+
+        function closeModal() {
+          document.getElementById('eventModal').style.display = 'none';
+          document.getElementById('modalBackdrop').style.display = 'none';
+        }
+    </script>
 
     <footer class="footer">
         <div class="container">

--- a/templates/calendar.html
+++ b/templates/calendar.html
@@ -1,0 +1,41 @@
+{% extends "base.html" %}
+
+{% block title %}Calendar - CNCF Kathmandu{% endblock %}
+
+{% block content %}
+<section class="page-header">
+    <div class="container">
+        <h1>Calendar</h1>
+        <p>View all our scheduled events in one place</p>
+    </div>
+</section>
+
+<div class="calendar-container">
+    <div id="calendar"></div>
+</div>
+
+<script>
+    document.addEventListener('DOMContentLoaded', function() {
+      var calendarEl = document.getElementById('calendar');
+
+      var calendar = new FullCalendar.Calendar(calendarEl, {
+        initialView: 'dayGridMonth',
+        events: [
+          {% for e in events %}
+          {
+            title: "{{ e.title|escape }}",
+            start: "{{ e.date }}",
+            description: "{{ e.description|escape }}",
+            speaker: "{{ e.speaker|escape }}"
+          },
+          {% endfor %}
+        ],
+        eventClick: function(info) {
+          openModal(info.event);
+        }
+      });
+
+      calendar.render();
+    });
+</script>
+{% endblock %}


### PR DESCRIPTION
This resolves issue #22 

### Event Calendar View Integration 

This PR introduces a calendar view for the actual events using FullCalendar, along with a modal popup for viewing event details.

#### Key changes:
- Integrated FullCalendar into `calendar.html` with dynamic event rendering from `events_db`
- Added modal HTML to `base.html` for global availability across templates
- Implemented `openModal()` and `closeModal()` functions to handle event click interactions
- Styled calendar and modal using global CSS variables (`style.css`)
- Ensured modal is hidden by default and appears centered with backdrop on event click

#### Why is this important:
This improves the user experience by allowing visitors to view event details directly from the calendar, without navigating away from the page. 

#### Screenshots

<img width="1494" height="922" alt="image" src="https://github.com/user-attachments/assets/0a4519d5-a4e4-47b9-8db7-b95d503ee8ce" />

<img width="1494" height="922" alt="image" src="https://github.com/user-attachments/assets/849e5735-28dd-4ee2-964e-f730e496df84" />
